### PR TITLE
Fixed constraint not working in person controller

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -30,7 +30,7 @@ def person():
 
     # using constraints to execute a query with in a smartgrid, we're using this to only get the
     # role_membership records of this current person.
-    role_memberships = SQLFORM.smartgrid(db.role_membership, constraints=dict(role_memberships=query),
+    role_memberships = SQLFORM.smartgrid(db.role_membership, constraints=dict(role_membership=query),
                                          onvalidation=NO_MEMBERSHIP_PERIOD_OVERLAP)
     if form.process().accepted:
         response.flash = T('Saved changes')

--- a/models/db_persona.py
+++ b/models/db_persona.py
@@ -35,7 +35,6 @@ db.define_table('role',
                 Field('name', 'string', required=True, unique=True, label=T('Name'),
                       requires=[IS_NOT_EMPTY(),
                                 CAPITALIZE(),
-                                IS_ALPHANUMERIC(),
                                 IS_NOT_IN_DB(db, 'role.name')]
                       ),
                 singular=T("Role"),


### PR DESCRIPTION
for some reason, `constraints=dict(role_memberships=query)` sometimes wouldn't show records that only belong to the current person, meaning you can see everyone's role_membership records on a single person's page. `contraints=dict(role_membership=query)` seems to work.